### PR TITLE
feat(docker): add initialize-onchain to copy files to docker volume

### DIFF
--- a/docker/sui/compose.yaml
+++ b/docker/sui/compose.yaml
@@ -19,6 +19,15 @@ x-validator-base: &validator-base
       condition: service_completed_successfully
 
 services:
+  initialize-onchain:
+    image: alpine:latest
+    container_name: initialize-onchain
+    command: ["sh", "-c", "cp -r /source/* /data"]
+    volumes:
+      - ../../onchain:/source:ro
+      - onchain:/data
+    restart: "no"
+
   build-suitools:
     container_name: build-suitools
     restart: "no"
@@ -62,11 +71,13 @@ services:
       - ./bin/publish_package.sh:/opt/sui/publish_package.sh:ro
       - ./genesis/static/client.yaml:/opt/sui/config/client.yaml:rw
       - ./genesis/static/sui.keystore:/opt/sui/config/sui.keystore:ro
-      - ../../onchain:/opt/sui/onchain
+      - onchain:/opt/sui/onchain
     command: ["bash", "/opt/sui/publish_package.sh"]
     restart: on-failure
     depends_on:
       build-suitools:
+        condition: service_completed_successfully
+      initialize-onchain:
         condition: service_completed_successfully
 
   validator1:
@@ -227,6 +238,7 @@ services:
         condition: service_healthy
 
 volumes:
+  onchain:
   genesis:
   validator1-db:
   validator2-db:


### PR DESCRIPTION
## Description

Fix Permission Denied Error for sui move test Execution
Resolved a "permission denied" issue occurring during sui move test by updating the Docker build process. Instead of directly mounting the project folder, files are now copied to a Docker volume, preventing permission changes that impacted local development.

## Fixes
https://github.com/Talus-Network/nexus/issues/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new service, `initialize-onchain`, to enhance data management during startup.
	- Added a new volume named `onchain` for improved service functionality.

- **Improvements**
	- Modified the `publish-package` service to utilize the new `onchain` volume, streamlining the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->