### PR TITLE
Corrected verb tense in project description for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ graph TD
 
 ## Looking forward
 
-Our first iteration had focused on feasibility, and as an aid in exploring the design space. You
+Our first iteration focused on feasibility, and as an aid in exploring the design space. You
 can build agents that work end-to-end. Here are some thoughts, which also give you an idea of
 some of the things we are actively working on:
 


### PR DESCRIPTION
In the project documentation, the sentence "Our first iteration had focused on feasibility" used the past perfect tense ("had focused"). However, this tense is not necessary here, as the simple past ("focused") would be more appropriate and clearer in the context. The change improves readability and aligns the sentence with conventional usage in project timelines.

Thanks for review!