### PR TITLE
Fix Typos in `oneclick-test.sh`, `talus_ollama.py`, and `test_agent.py`

### DIFF
--- a/e2e_tests/oneclick-test.sh
+++ b/e2e_tests/oneclick-test.sh
@@ -6,7 +6,7 @@
 #
 # The script assumes:
 # - sui CLI, jq, cargo
-# - env var SUI_WALLET_PATH poiting to the wallet yaml
+# - env var SUI_WALLET_PATH pointing to the wallet yaml
 #   or it can be alternatively defined in .env file (see README)
 # - pwd is a git repo
 #

--- a/offchain/tools/src/nexus_tools/server/crew/talus_ollama.py
+++ b/offchain/tools/src/nexus_tools/server/crew/talus_ollama.py
@@ -1,4 +1,4 @@
-### This class will basically overrides the LLM implementaion for Ollama as we added
+### This class will basically overrides the LLM implementation for Ollama as we added
 ### the ability to report usage per agent request, the logic here is to be able to chrage
 
 

--- a/offchain/tools/tests/test_agent.py
+++ b/offchain/tools/tests/test_agent.py
@@ -12,7 +12,7 @@ client = TestClient(app)
 @pytest.mark.unit
 def test_create_agents_and_tasks():
     request_company_descriptiondata = {
-        "desciption": "A tech company specializing in AI solutions.",
+        "description": "A tech company specializing in AI solutions.",
         "company_domain": "ai-tech.com",
         "hiring_needs": "Senior AI Engineer",
         "specific_benefits": "Remote work, flexible hours, stock options",


### PR DESCRIPTION
1. **`oneclick-test.sh`**:
   - Fixed "poiting" to "pointing" in the environment variable description.

2. **`talus_ollama.py`**:
   - Corrected "implementaion" to "implementation" in a comment about overriding LLM functionality.

3. **`test_agent.py`**:
   - Fixed "desciption" to "description" in the test data dictionary.
